### PR TITLE
Preview plans

### DIFF
--- a/sixtools/info_functions.py
+++ b/sixtools/info_functions.py
@@ -1,7 +1,7 @@
 from blueksy import simulators
 
 
-def list_scans(plan):
+def list_scans(plan, db):
     '''Print a summary of a plan, with some SIX specific info
 
     Prints a version of the plan, showing moves that occur outside of runs, and
@@ -22,6 +22,9 @@ def list_scans(plan):
     ----------
     plan: iterable
         must yield'Msg' objects
+
+    db: databroker.
+        The databroker that the scans are being logged in.
 
     '''
 
@@ -51,7 +54,8 @@ def list_scans(plan):
                 changed_motors.append(','+set_string)
 
 
-def check_plan(plan, check_limits=True, scan_list=True, summarize_plan=False):
+def check_plan(plan, db, check_limits=True, scan_list=True,
+               summarize_plan=False):
     '''This is meant to be a 'complete' collection of all possible 'prechecks'
        for plans.
 
@@ -64,6 +68,9 @@ def check_plan(plan, check_limits=True, scan_list=True, summarize_plan=False):
     ----------
     plan: generator.
         The plan generator that is to be checked.
+
+    db: databroker.
+        The databroker that the scans are being logged in.
 
     check_limits: boolean, optional.
         A boolean that indicates if the limits should be checked for this plan.

--- a/sixtools/info_functions.py
+++ b/sixtools/info_functions.py
@@ -35,18 +35,18 @@ def list_scans(plan, db):
 
     '''
 
-    in_run = 0  # A way to track if we are in a run or not.
+    in_run = False  # A way to track if we are in a run or not.
     prev_scanID = db[-1].start['scan_id']  # The previous scan ID
     changed_motors = ''  # The value of any changed motors
 
     for msg in plan:
         if in_run:
             if msg.command == 'close_run':
-                in_run = 0
+                in_run = False
                 changed_motors = ''
         else:
             if msg.command == 'open_run':
-                in_run = 1
+                in_run = True
                 prev_scanID += 1
                 scan_string = 'scan no {}'.format(prev_scanID)
                 try:  # If a reason is given in the metadata include it.

--- a/sixtools/info_functions.py
+++ b/sixtools/info_functions.py
@@ -18,6 +18,13 @@ def list_scans(plan, db):
         given by the 'reason' kwarg in he scans metadata and Yi is the value
         that motor1 was set too prior to running the scan.
 
+    A partial reference to this should be made in the startup folder using:
+
+    .. codeblock:: python
+       from sixtools import list_scans
+       def list_scans = partial(list_scans, db=db)
+
+
     Parameters
     ----------
     plan: iterable
@@ -64,6 +71,12 @@ def check_plan(plan, db, check_limits=True, scan_list=True,
     every step, but this can be added by setting the summarize_plan kwarg to
     True.
 
+    A partial reference to this should be made in the startup folder using:
+
+    .. codeblock:: python
+       from sixtools import check_plan
+       def check_plan = partial(check_plan, db=db)
+
     Parameters
     ----------
     plan: generator.
@@ -87,7 +100,7 @@ def check_plan(plan, db, check_limits=True, scan_list=True,
         simulators.check_limits(plan)
 
     if scan_list:
-        list_scans(plan)
+        list_scans(plan, db)
 
     if summarize_plan:
         simulators.summarize_plan(plan)

--- a/sixtools/info_functions.py
+++ b/sixtools/info_functions.py
@@ -1,0 +1,48 @@
+
+def summarize_runs(plan):
+    '''Print a summary of a plan, with some SIX specific info
+
+    Prints a version of the plan, showing moves that occur outside of runs, and
+    potential scan id's for any runs. Note that the scan id's listed assume
+    that the first scan has the next scan_id inthe sequence, if there is an
+    aborted scan, or if other scans occur first, this may not be true.
+
+    If a 'reason' kwarg is included in the metadata this is also included in
+    the printout.
+
+    For example the expected printout for each run should be:
+    "scan no XXXX, 'reason', motor1 = Y1, motor2 = Y2, ......."
+        where XXXX is the expected scan ID, 'reason' is an optional string
+        given by the 'reason' kwarg in he scans metadata and Yi is the value
+        that motor1 was set too prior to running the scan.
+
+    Parameters
+    plan: iterable
+        must yield'Msg' objects
+
+    '''
+
+    in_run = 0  # A way to track if we are in a run or not.
+    prev_scanID = db[-1].start['scan_id']  # The previous scan ID
+    changed_motors = '' # The value of any changed motors
+
+    for msg in plan:
+        if in_run:
+            if msg.command == 'close_run'
+                in_run = 0
+                changed_motors = ''
+        else:
+            if msg.command == 'open_run'
+                in_run = 1
+                prev_scanID += 1
+                scan_string = 'scan no {}'.format(prev_scanID)
+                try:  # If a reason is given in the metadata include it.
+                    description = msg.kwargs['reason']
+                    description.append(', ')
+                except KeyError:
+                    description = ''
+
+                print (scan_string + ', ' + description + changed_motors)
+            elif msg.command == 'set'
+                set_string = msg.obj.name + ' = ' + msg.args
+                changed_motors.append(','+set_string)

--- a/sixtools/info_functions.py
+++ b/sixtools/info_functions.py
@@ -1,5 +1,7 @@
+from blueksy import simulators
 
-def summarize_runs(plan):
+
+def list_scans(plan):
     '''Print a summary of a plan, with some SIX specific info
 
     Prints a version of the plan, showing moves that occur outside of runs, and
@@ -17,6 +19,7 @@ def summarize_runs(plan):
         that motor1 was set too prior to running the scan.
 
     Parameters
+    ----------
     plan: iterable
         must yield'Msg' objects
 
@@ -24,15 +27,15 @@ def summarize_runs(plan):
 
     in_run = 0  # A way to track if we are in a run or not.
     prev_scanID = db[-1].start['scan_id']  # The previous scan ID
-    changed_motors = '' # The value of any changed motors
+    changed_motors = ''  # The value of any changed motors
 
     for msg in plan:
         if in_run:
-            if msg.command == 'close_run'
+            if msg.command == 'close_run':
                 in_run = 0
                 changed_motors = ''
         else:
-            if msg.command == 'open_run'
+            if msg.command == 'open_run':
                 in_run = 1
                 prev_scanID += 1
                 scan_string = 'scan no {}'.format(prev_scanID)
@@ -42,7 +45,42 @@ def summarize_runs(plan):
                 except KeyError:
                     description = ''
 
-                print (scan_string + ', ' + description + changed_motors)
-            elif msg.command == 'set'
+                print(scan_string + ', ' + description + changed_motors)
+            elif msg.command == 'set':
                 set_string = msg.obj.name + ' = ' + msg.args
                 changed_motors.append(','+set_string)
+
+
+def check_plan(plan, check_limits=True, scan_list=True, summarize_plan=False):
+    '''This is meant to be a 'complete' collection of all possible 'prechecks'
+       for plans.
+
+    This function is meant to be used to apply all possible prechecks for a
+    plan. By default it does not use the verbose 'summarize_plan' which shows
+    every step, but this can be added by setting the summarize_plan kwarg to
+    True.
+
+    Parameters
+    ----------
+    plan: generator.
+        The plan generator that is to be checked.
+
+    check_limits: boolean, optional.
+        A boolean that indicates if the limits should be checked for this plan.
+
+    scan_list: boolean, optional.
+        A boolean that indicates if the scans should be listed for this plan.
+
+    summarize_plan: boolean, optional.
+        A boolean that indicates if the full set of steps should be listed.
+
+    '''
+
+    if check_limits:
+        simulators.check_limits(plan)
+
+    if scan_list:
+        list_scans(plan)
+
+    if summarize_plan:
+        simulators.summarize_plan(plan)


### PR DESCRIPTION
This address [bluesky issue #1075](https://github.com/NSLS-II/bluesky/issues/1075) raised by @ambarb . I have created a 'custom' version of <bluesky.simulators.summarize_plans> hat gives an output very similar to that described in [bluesky issue #1075](https://github.com/NSLS-II/bluesky/issues/1075) . The printed output has the form:
"scan no XXXX, 'reason', motor1 = Y1, motor2 = Y2, ........"
    where XXXX is the expected scan ID, 'reason' is an optional string given by the 'reason' kwarg in the scans metadata and Yi is the value that motori was set too prior to running the scan.

NOTES: 'reason' is ignored if it is not present as a kwarg in the metatdata, only motors that are 'set' between 'scans' are recorded.

To get the equivalent output requested in [bluesky issue #1075](https://github.com/NSLS-II/bluesky/issues/1075) the kwarg 'reason' would need to be set to 'sample 3 A, pol = V' or 'dark' depending on the scan.

Based on discussion with @ambarb I have also included a 'check_plan' function which combines all of the currently offered 'simulators'. In this by default <summarize_plan> is ignored.