### PR TITLE
Make image_to_spectrum catch and not forgive mistakes with background

### DIFF
--- a/sixtools/plotting_functions.py
+++ b/sixtools/plotting_functions.py
@@ -38,7 +38,7 @@ def plot_frame(ax, frame, light_ROIs=[], cax=None, **kwargs):
     kwargs.update({key: val for key, val in defaults.items()
                    if key not in kwargs})
 
-    art = ax.imshow(frame, **kwargs)
+    art = ax.pcolorfast(frame, **kwargs)
     if cax is None:
         divider = make_axes_locatable(ax)
         cax = divider.append_axes("right", size="2%", pad=0.1)

--- a/sixtools/rixs_wrapper.py
+++ b/sixtools/rixs_wrapper.py
@@ -58,11 +58,11 @@ def image_to_spectrum(image, light_ROI=[slice(None, None, None),
     spectrum : array
         two column array of pixel, intensity
     """
-    try:
+    if background is None:
+        photon_events = image_to_photon_events(image[light_ROI])
+    else:
         photon_events = image_to_photon_events(image[light_ROI]
                                                - background[light_ROI])
-    except TypeError:
-        photon_events = image_to_photon_events(image[light_ROI])
 
     spectrum = apply_curvature(photon_events, curvature, bins)
     return spectrum


### PR DESCRIPTION
@bisogni and @ambarb requested that 
`image_to_spectrum`
Does not forgive instances where the background subtraction fails.

In this pull request 
`image_to_spectrum`
will be silent is the data flow proceeds with or without a sucessful background subtration. Otherwise, it will throw an error. 