### PR TITLE
Update for centroided data

### DIFF
--- a/example_notebooks/Alignment.ipynb
+++ b/example_notebooks/Alignment.ipynb
@@ -71,13 +71,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "process_dicts = {'low_2theta': {'light_ROI': [slice(175, 1500), slice(3650, 4200)],\n",
+    "process_dicts = {'low_2theta': {'light_ROI': [3650, 4200, 175, 1500],\n",
     "                                'curvature': np.array([0., 0., 0.]),\n",
-    "                                'bins': None,\n",
+    "                                'bins': 1,\n",
+    "                                'detector': 'rixscam_image',\n",
     "                                'background': None},\n",
-    "                 'high_2theta': {'light_ROI': [slice(175, 1500), slice(1020, 1450)],\n",
+    "                 'high_2theta': {'light_ROI': [1020, 1450, 175, 1500],\n",
     "                                 'curvature': np.array([0., 0., 0.]),\n",
-    "                                 'bins': None,\n",
+    "                                 'bins': 1,\n",
+    "                                 'detector': 'rixscam_image',\n",
     "                                 'background': None}\n",
     "                }\n",
     "\n",
@@ -270,9 +272,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (mark_six)",
+   "display_name": "MPMD_SIX_from_2018-3.2",
    "language": "python",
-   "name": "mark_six"
+   "name": "myenv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -284,7 +286,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/example_notebooks/Analyze_scan_energy_map.ipynb
+++ b/example_notebooks/Analyze_scan_energy_map.ipynb
@@ -57,13 +57,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "process_dicts = {'low_2theta': {'light_ROI': [slice(175, 1500), slice(4130, 4700)],\n",
+    "process_dicts = {'low_2theta': {'light_ROI': [4130, 4700, 175, 1500],\n",
     "                                'curvature': np.array([0., 0., 0.]),\n",
-    "                                'bins': None,\n",
+    "                                'bins': 1,\n",
+    "                                'detector': 'rixscam_image',                                \n",
     "                                'background': None},\n",
-    "                 'high_2theta': {'light_ROI': [slice(175, 1500), slice(1153, 1531)],\n",
+    "                 'high_2theta': {'light_ROI': [1153, 1531, 175, 1500],\n",
     "                                 'curvature': np.array([0., 0., 0.]),\n",
-    "                                 'bins': None,\n",
+    "                                 'bins': 1,\n",
+    "                                 'detector': 'rixscam_image',\n",
     "                                 'background': None}\n",
     "                }\n",
     "\n",
@@ -142,7 +144,9 @@
     "fig_frames = plt.figure(num=1, figsize=(10, 4), clear=True)\n",
     "ax_frames = fig_frames.add_subplot(111)\n",
     "\n",
-    "art_frames, _, cb_frames = plot_frame(ax_frames, frames[0,0], light_ROIs=light_ROIs)\n",
+    "art_frames, _, cb_frames = plot_frame(ax_frames, frames[0,0], light_ROIs=light_ROIs,\n",
+    "                                     vmin=np.nanpercentile(frames[0,0], 1),\n",
+    "                                     vmax=np.nanpercentile(frames[0,0], 99))\n",
     "\n",
     "ax_frames.set_title(\"Frame {}_{}\".format(event_labels[0], 0))\n",
     "\n",
@@ -162,8 +166,8 @@
     "\n",
     "scanid_widget = Dropdown(options=scan_ids)\n",
     "frameid_widget = IntSlider(min=0, max=frames.shape[1]-1)\n",
-    "vmin_widget1 = FloatText()\n",
-    "vmax_widget1 = FloatText()\n",
+    "vmin_widget1 = FloatText(value=np.nanpercentile(frames[0,0], 1))\n",
+    "vmax_widget1 = FloatText(value=np.nanpercentile(frames[0,0], 1))\n",
     "\n",
     "grab = interactive(update_frame, scan_id=scanid_widget, frameid=frameid_widget, vmin=vmin_widget1, vmax=vmax_widget1)\n",
     "\n",
@@ -350,13 +354,20 @@
     "\n",
     "display(fig_map.canvas, vin_widget3, vmax_widget3)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (mark_six)",
+   "display_name": "MPMD_SIX_from_2018-3.2",
    "language": "python",
-   "name": "mark_six"
+   "name": "myenv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -368,7 +379,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/example_notebooks/fit_curvature.ipynb
+++ b/example_notebooks/fit_curvature.ipynb
@@ -55,13 +55,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "process_dicts = {'low_2theta': {'light_ROI': [slice(175, 1500), slice(4130, 4700)],\n",
+    "process_dicts = {'low_2theta': {'light_ROI': [4130, 4700, 175, 1500],\n",
     "                                'curvature': np.array([0., 0., 0.]),\n",
-    "                                'bins': None,\n",
+    "                                'bins': 1,\n",
+    "                                'detector': 'rixscam_image',\n",
     "                                'background': None},\n",
-    "                 'high_2theta': {'light_ROI': [slice(175, 1500), slice(900, 1300)],\n",
+    "                 'high_2theta': {'light_ROI': [900, 1300, 175, 1500],\n",
     "                                 'curvature': np.array([0., 0., 0.]),\n",
-    "                                 'bins': None,\n",
+    "                                 'bins': 1,\n",
+    "                                 'detector': 'rixscam_image',\n",
     "                                 'background': None}\n",
     "                }\n",
     "\n",
@@ -163,9 +165,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:main_new]",
+   "display_name": "MPMD_SIX_from_2018-3.2",
    "language": "python",
-   "name": "conda-env-main_new-py"
+   "name": "myenv"
   },
   "language_info": {
    "codemirror_mode": {

--- a/example_notebooks/plot_centroid_data.ipynb
+++ b/example_notebooks/plot_centroid_data.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from databroker import DataBroker as db\n",
+    "from sixtools.rixs_wrapper import make_scan, centroids_to_spectrum, get_rixs\n",
+    "\n",
+    "from IPython.display import clear_output, display\n",
+    "%matplotlib widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "fig_scan = plt.figure(num=0, clear=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define and execute processing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scan_ids = 51227\n",
+    "#sum_image = sum(im for event in db[51227].data('rixscam_image') for im in event)\n",
+    "process_dicts = {'low_2theta': {'light_ROI': [4130, 4700, 175, 1500],\n",
+    "                                'curvature': np.array([0., 0., 0.]),\n",
+    "                                'bins': 1,\n",
+    "                                'background': None},\n",
+    "                 'high_2theta': {'light_ROI': [800, 1230, 175, 1500],\n",
+    "                                 'curvature': np.array([0., 0., 0.]),\n",
+    "                                 'bins': 1,\n",
+    "                                 'background': None}\n",
+    "                }\n",
+    "\n",
+    "\n",
+    "scan_images = make_scan(db[51227], detector='rixscam_image', **process_dicts['high_2theta'])\n",
+    "scan_centroids = make_scan(db[51227], detector='rixscam_centroids', **process_dicts['high_2theta'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot scans"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "S_images = scan_images.mean(axis=(0,1))\n",
+    "S_cenroids = scan_centroids.mean(axis=(0,1))\n",
+    "ax.plot(S_images[:,0], S_images[:,1] - S_images[0,1], '.-', label='images')\n",
+    "ax.plot(S_cenroids[:,0], S_cenroids[:,1], '.-', label='centroids')\n",
+    "#ax.plot(spec[:,0], (spec[:,1]- spec[0,1])/10000, label='simple')\n",
+    "\n",
+    "ax.legend()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "MPMD_SIX_from_2018-3.2",
+   "language": "python",
+   "name": "myenv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/example_notebooks/plot_centroid_data.ipynb
+++ b/example_notebooks/plot_centroid_data.ipynb
@@ -83,7 +83,6 @@
     "S_cenroids = scan_centroids.mean(axis=(0,1))\n",
     "ax.plot(S_images[:,0], S_images[:,1] - S_images[0,1], '.-', label='images')\n",
     "ax.plot(S_cenroids[:,0], S_cenroids[:,1], '.-', label='centroids')\n",
-    "#ax.plot(spec[:,0], (spec[:,1]- spec[0,1])/10000, label='simple')\n",
     "\n",
     "ax.legend()"
    ]

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setup(
     name='sixtools',
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    description="Software for performing resonant inelastic xray scattering analysis at NSLS-II",
+    description=("Software for performing resonant inelastic"
+                 " xray scattering analysis at NSLS-II"),
     long_description=readme,
     author="Brookhaven National Lab",
     author_email='awalter@bnl.gov',

--- a/sixtools/plotting_functions.py
+++ b/sixtools/plotting_functions.py
@@ -49,9 +49,9 @@ def plot_frame(ax, frame, light_ROIs=[], cax=None, **kwargs):
 
     for light_ROI in light_ROIs:
         box = Rectangle((light_ROI[0], light_ROI[2]),
-                light_ROI[1]-light_ROI[0],
-                light_ROI[3]-light_ROI[2],
-                facecolor='none', edgecolor='w')
+                        light_ROI[1]-light_ROI[0],
+                        light_ROI[3]-light_ROI[2],
+                        facecolor='none', edgecolor='w')
         ax.add_patch(box)
 
     return art, cax, cb

--- a/sixtools/plotting_functions.py
+++ b/sixtools/plotting_functions.py
@@ -14,8 +14,10 @@ def plot_frame(ax, frame, light_ROIs=[], cax=None, **kwargs):
         axis to plot frame on
     frame : array
         2D image to plot
-    light_ROIs : list of [slice, slice]
-        Regions of interest to plot as white rectangles
+    light_ROI : list of lists
+        [[minx, maxx, miny, maxy], ...]
+        Define the region of the sensor to use.
+        Events are chosen with minx <= x < maxx and miny <= y < maxy
     cax : None or matplotlib axis object
         axis to plot colorbar on
         If none a colorbar is created
@@ -46,13 +48,10 @@ def plot_frame(ax, frame, light_ROIs=[], cax=None, **kwargs):
     cb = plt.colorbar(art, cax=cax)
 
     for light_ROI in light_ROIs:
-        row_i = light_ROI[0].start
-        row_f = light_ROI[0].stop
-        col_i = light_ROI[1].start
-        col_f = light_ROI[1].stop
-
-        box = Rectangle((col_i, row_i), (col_f-col_i), (row_f-row_i),
-                        facecolor='none', edgecolor='w')
+        box = Rectangle((light_ROI[0], light_ROI[2]),
+                light_ROI[1]-light_ROI[0],
+                light_ROI[3]-light_ROI[2],
+                facecolor='none', edgecolor='w')
         ax.add_patch(box)
 
     return art, cax, cb

--- a/sixtools/rixs_wrapper.py
+++ b/sixtools/rixs_wrapper.py
@@ -68,8 +68,8 @@ def centroids_to_spectrum(table, light_ROI=[0, np.inf, 0, np.inf],
                                     table['x_eta'] < light_ROI[1],
                                     table['y_eta'] >= light_ROI[2],
                                     table['y_eta'] < light_ROI[3],
-                                    table['y_eta'] >= min_threshold,
-                                    table['y_eta'] < max_threshold))
+                                    table['sum_regions'] >= min_threshold,
+                                    table['sum_regions'] < max_threshold))
 
     photon_events = table[choose][['x_eta', 'y_eta', 'sum_regions']].values
     photon_events[:, 2] = photon_events[:, 2]/ADU_per_photon

--- a/sixtools/rixs_wrapper.py
+++ b/sixtools/rixs_wrapper.py
@@ -1,27 +1,77 @@
 import numpy as np
+import pandas as pd
 from scipy.interpolate import interp1d
 from pims import pipeline
 from rixs.process2d import apply_curvature, image_to_photon_events
+from rixs.process2d import step_to_bins
 
 # Eventually we will create this information from the configuration
 # attributes in ophyd.
-process_dict_low_2theta = {'light_ROI': [slice(175, 1609), slice(1, 1751)],
+process_dict_low_2theta = {'light_ROI': [175, 1609, 1, 1751],
                            'curvature': np.array([0., 0., 0.]),
-                           'bins': None}
+                           'bins': 1}
 
-process_dict_high_2theta = {'light_ROI': [slice(175, 1609), slice(1753, 3503)],
+process_dict_high_2theta = {'light_ROI': [175, 1609, 1753, 3503],
                             'curvature': np.array([0., 0., 0.]),
-                            'bins': None}
+                            'bins': 1}
 
 
 process_dicts = {'low_2theta': process_dict_low_2theta,
                  'high_2theta': process_dict_high_2theta}
 
 
+def centroids_to_spectrum(table, light_ROI=[0, np.inf, 0, np.inf],
+                          curvature=np.array([0., 0., 0.]), bins=1,
+                          ADU_per_photon=1):
+    """
+    Convert a table of centroided events into a spectrum
+
+    Parameters
+    ----------
+    table : pandas table
+        centroided RIXS photon events
+    light_ROI : [minx, maxx, miny, maxy]
+        Define the region of the sensor to use.
+        Events are chosen with minx <= x < maxx and miny <= y < maxy
+    curvature : array
+        The polynominal coeffcients describing the image curvature.
+        These are in decreasing order e.g.
+        .. code-block:: python
+
+           curvature[0]*x**2 + curvature[1]*x**1 + curvature[2]*x**0
+        The order of polynominal used is set by len(curvature) - 1
+    bins : float or array like
+        Binning in the y direction.
+        If `bins` is a sequence, it defines the bin edges,
+        including the rightmost edge.
+        If `bins' is a single number this defines the step
+        in the bins sequence, which is created using the min/max
+        of the input data. Half a bin may be discarded in order
+        to avoid errors at the edge. (Default 1.)
+    ADU_per_photon : float
+        Conversion factor between the input intensity values in tabel
+        and photons. (Default is 1)
+
+    Yields
+    ------
+    spectrum : array
+        two column array of pixel, intensity
+    """
+    choose = np.logical_and.reduce((table['x_eta'] >= light_ROI[0],
+                                    table['x_eta'] < light_ROI[1],
+                                    table['y_eta'] >= light_ROI[2],
+                                    table['y_eta'] < light_ROI[3]))
+
+    photon_events = table[choose][['x_eta', 'y_eta', 'sum_regions']].values
+    photon_events[:, 2] /= ADU_per_photon
+    spectrum = apply_curvature(photon_events, curvature, bins)
+    return spectrum
+
+
 @pipeline
-def image_to_spectrum(image, light_ROI=[slice(None, None, None),
-                                        slice(None, None, None)],
-                      curvature=np.array([0., 0., 0.]), bins=None,
+def image_to_spectrum(image, light_ROI=[0, np.inf, 0, np.inf],
+                      curvature=np.array([0., 0., 0.]), bins=1,
+                      ADU_per_photon=1,
                       background=None):
     """
     Convert a 2D array of RIXS data into a spectrum
@@ -30,8 +80,9 @@ def image_to_spectrum(image, light_ROI=[slice(None, None, None),
     ----------
     image : array
         2D array of intensity
-    light_ROI : [slice, slice]
-        Region of image containing the data
+    light_ROI : [minx, maxx, miny, maxy]
+        Define the region of the sensor to use.
+        Events are chosen with minx <= x < maxx and miny <= y < maxy
     curvature : array
         The polynominal coeffcients describing the image curvature.
         These are in decreasing order e.g.
@@ -39,17 +90,17 @@ def image_to_spectrum(image, light_ROI=[slice(None, None, None),
 
            curvature[0]*x**2 + curvature[1]*x**1 + curvature[2]*x**0
         The order of polynominal used is set by len(curvature) - 1
-    bins : int or array_like or [int, int] or [array, array]
-        The bin specification in y then x order:
-            * If int, the number of bins for the two dimensions (nx=ny=bins).
-            * If array_like, the bin edges for the two dimensions
-              (y_edges=x_edges=bins).
-            * If [int, int], the number of bins in each dimension
-              (ny, nx = bins).
-            * If [array, array], the bin edges in each dimension
-              (y_edges, x_edges = bins).
-            * A combination [int, array] or [array, int], where int
-              is the number of bins and array is the bin edges.
+    bins : float or array like
+        Binning in the y direction.
+        If `bins` is a sequence, it defines the bin edges,
+        including the rightmost edge.
+        If `bins' is a single number this defines the step
+        in the bins sequence, which is created using the min/max
+        of the input data. Half a bin may be discarded in order
+        to avoid errors at the edge. (Default 1.)
+    ADU_per_photon : float
+        Conversion factor between the input intensity values in tabel
+        and photons. (Default is 1)
     background : array
         2D array for background subtraction
 
@@ -58,21 +109,36 @@ def image_to_spectrum(image, light_ROI=[slice(None, None, None),
     spectrum : array
         two column array of pixel, intensity
     """
-    if background is None:
-        photon_events = image_to_photon_events(image[light_ROI])
-    else:
-        photon_events = image_to_photon_events(image[light_ROI]
-                                               - background[light_ROI])
+    num_rows, num_cols = image.shape
+    if light_ROI[1] is np.inf:
+        light_ROI[1] = num_cols
+    if light_ROI[3] is np.inf:
+        light_ROI[3] = num_rows
+    choose = (slice(light_ROI[2], light_ROI[3]),
+              slice(light_ROI[0], light_ROI[1]))
 
+    x_centers = np.arange(light_ROI[0], light_ROI[1])
+    y_centers = np.arange(light_ROI[2], light_ROI[3])
+
+    if background is None:
+        ph_e = image_to_photon_events(image[choose],
+                                      x_centers=x_centers,
+                                      y_centers=y_centers)
+    else:
+        ph_e = image_to_photon_events(image[choose] -
+                                      background[choose],
+                                      x_centers=x_centers,
+                                      y_centers=y_centers)
+
+    photon_events = ph_e
+    photon_events[:, 2] = ADU_per_photon
     spectrum = apply_curvature(photon_events, curvature, bins)
     return spectrum
 
 
-def get_rixs(header, light_ROI=[slice(None, None, None),
-                                slice(None, None, None)],
-             curvature=np.array([0., 0., 0.]), bins=None,
-             background=None,
-             detector='rixscam_image'):
+def get_rixs(header, light_ROI=[0, np.inf, 0, np.inf],
+             curvature=np.array([0., 0., 0.]), bins=1, ADU_per_photon=1,
+             detector='rixscam_centroids', background=None):
     """
     Create rixs spectra according to procces_dict
     and return data as generator with similar behavior to
@@ -82,8 +148,9 @@ def get_rixs(header, light_ROI=[slice(None, None, None),
     ----------
     header : databroker header object
         A dictionary-like object summarizing metadata for a run.
-    light_ROI : [slice, slice]
-        Region of image containing the data
+    light_ROI : [minx, maxx, miny, maxy]
+        Define the region of the sensor to use.
+        Events are chosen with minx <= x < maxx and miny <= y < maxy
     curvature : array
         The polynominal coeffcients describing the image curvature.
         These are in decreasing order e.g.
@@ -91,38 +158,69 @@ def get_rixs(header, light_ROI=[slice(None, None, None),
 
            curvature[0]*x**2 + curvature[1]*x**1 + curvature[2]*x**0
         The order of polynominal used is set by len(curvature) - 1
-    bins : int or array_like or [int, int] or [array, array]
-        The bin specification in y then x order:
-            * If bins is None a step of 1 is assumed over the relevant range
-            * If int, the number of bins for the two dimensions (nx=ny=bins).
-            * If array_like, the bin edges for the two dimensions
-              (y_edges=x_edges=bins).
-            * If [int, int], the number of bins in each dimension
-              (ny, nx = bins).
-            * If [array, array], the bin edges in each dimension
-              (y_edges, x_edges = bins).
-            * A combination [int, array] or [array, int], where int
-              is the number of bins and array is the bin edges.
-    background : array
-        2D array for background subtraction
+    bins : float or array like
+        Binning in the y direction.
+        If `bins` is a sequence, it defines the bin edges,
+        including the rightmost edge.
+        If `bins' is a single number this defines the step
+        in the bins sequence, which is created using the min/max
+        of the input data. Half a bin may be discarded in order
+        to avoid errors at the edge. (Default 1.)
+    ADU_per_photon : float
+        Conversion factor between the input intensity values in table
+        and photons. (Default is 1)
     detector : string
         name of the detector passed on header.data
+        At SIX
+        'rixscam_centroids' is the centroided data, which is the default
+        'rixscam_image' is the image data
+    background : array
+        2D array for background subtraction
+        Only used for image data.
 
     Yields
     -------
-    ImageStack : pims ImageStack or list of ImageStack
-        Array-like object contains scans associated with an event.
-        If the input is a list of headers the output is a list of
+    spectra : generator
+        RIXS spectra are returned as a generator
     """
-    for ImageStack in header.data(detector):
-        yield image_to_spectrum(ImageStack, light_ROI=light_ROI,
-                                curvature=curvature, bins=bins,
-                                background=background)
+    if detector == 'rixscam_centroids':
+        try:
+            iter(bins)
+        except TypeError:
+            total_table = pd.concat(t for event in header.data(detector)
+                                    for t in event)
+            bins = step_to_bins(total_table['y_eta'].min(),
+                                total_table['y_eta'].max(), bins)
+
+        pgm_en = header.table(stream_name='baseline',
+                              fields=['pgm_en']).mean().values.mean()
+        if np.isnan(pgm_en):
+            pgm_en = header.table(fields=['pgm_en']).mean().values.mean()
+
+        ADU_per_photon = pgm_en * 1.12
+
+        for event in header.data(detector):
+                yield [centroids_to_spectrum(table, light_ROI=light_ROI,
+                                             curvature=curvature, bins=bins,
+                                             ADU_per_photon=ADU_per_photon)
+                       for table in event]
+    elif detector == 'rixscam_image':
+        for ImageStack in header.data(detector):
+            yield image_to_spectrum(ImageStack, light_ROI=light_ROI,
+                                    curvature=curvature, bins=bins,
+                                    background=background)
+    else:
+        raise Warning("detector {} not reconized, but we will try to"
+                      "return data in any case.".format(detector))
+        for ImageStack in header.data(detector):
+            yield image_to_spectrum(ImageStack, light_ROI=light_ROI,
+                                    curvature=curvature, bins=bins,
+                                    background=background)
 
 
-def make_scan(headers, light_ROI=[slice(None, None, None),
-                                  slice(None, None, None)],
-              curvature=np.array([0., 0., 0.]), bins=None,
+def make_scan(headers, light_ROI=[0, np.inf, 0, np.inf],
+              curvature=np.array([0., 0., 0.]), bins=1,
+              detector='rixscam_centroids',
               background=None):
     """
     Make 4D array of RIXS spectra with structure
@@ -132,8 +230,9 @@ def make_scan(headers, light_ROI=[slice(None, None, None),
     ----------
     headers : databroker header object or iterable of same
         iterable that returns databroker objects
-    light_ROI : [slice, slice]
-        Region of image containing the data
+    light_ROI : [minx, maxx, miny, maxy]
+        Define the region of the sensor to use.
+        Events are chosen with minx <= x < maxx and miny <= y < maxy
     curvature : array
         The polynominal coeffcients describing the image curvature.
         These are in decreasing order e.g.
@@ -141,19 +240,22 @@ def make_scan(headers, light_ROI=[slice(None, None, None),
 
            curvature[0]*x**2 + curvature[1]*x**1 + curvature[2]*x**0
         The order of polynominal used is set by len(curvature) - 1
-    bins : int or array_like or [int, int] or [array, array]
-        The bin specification in y then x order:
-            * If int, the number of bins for the two dimensions (nx=ny=bins).
-            * If array_like, the bin edges for the two dimensions
-              (y_edges=x_edges=bins).
-            * If [int, int], the number of bins in each dimension
-              (ny, nx = bins).
-            * If [array, array], the bin edges in each dimension
-              (y_edges, x_edges = bins).
-            * A combination [int, array] or [array, int], where int
-              is the number of bins and array is the bin edges.
+    bins : float or array like
+        Binning in the y direction.
+        If `bins` is a sequence, it defines the bin edges,
+        including the rightmost edge.
+        If `bins' is a single number this defines the step
+        in the bins sequence, which is created using the min/max
+        of the input data. Half a bin may be discarded in order
+        to avoid errors at the edge. (Default 1.)
+    detector : string
+        name of the detector passed to header.data
+        At SIX
+        'rixscam_centroids' is the centroided data, which is the default
+        'rixscam_image' is the image data
     background : array
         2D array for background subtraction
+        Only used for image data.
 
     Returns
     -------
@@ -165,7 +267,8 @@ def make_scan(headers, light_ROI=[slice(None, None, None),
         headers = [headers]
 
     rixs_generators = [get_rixs(h, light_ROI=light_ROI, curvature=curvature,
-                                bins=bins, background=background)
+                                bins=bins, detector=detector,
+                                background=background)
                        for h in headers]
 
     scan = np.concatenate([np.array([s for s in rg])


### PR DESCRIPTION
This includes routines for processing centroided data. 

A couple of notes:
-- When coding this, I decided to change the way ROIs are set as the previously used python slices cannot be directly applied to the centroided data. 
-- Previously setting a ROI redefined the effective zero pixel definition in the returned data. This was okay in itself, but is problematic if one wants to compare image and centroided data. The way that bins are defined was consequently also changed. 
-- Setup.py was changed to comply with flake8
-- A new notebook was added comparing centroided and non-centroided data. Minor updates to the other notebooks are needed for compatbility.
-- Small updates to scikit-beam rixs are also needed to run this. 